### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fetchsync.yml
+++ b/.github/workflows/fetchsync.yml
@@ -1,5 +1,8 @@
 name: Fetch & Sync Repositories
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/ZoneCog/mem0ai-central/security/code-scanning/2](https://github.com/ZoneCog/mem0ai-central/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are needed:
- `contents: read` for reading repository contents.
- `contents: write` for pushing changes to the repository.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level to scope permissions more granularly. In this case, adding it at the root level is sufficient and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
