### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fetchsyncme.yml
+++ b/.github/workflows/fetchsyncme.yml
@@ -1,4 +1,6 @@
 name: Fetch & Sync Repositories
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ZoneCog/mem0ai-central/security/code-scanning/8](https://github.com/ZoneCog/mem0ai-central/security/code-scanning/8)

To fix the issue, we will add a `permissions` block to the workflow. This block will be added at the root level to apply to all jobs in the workflow. Based on the workflow's actions, the following permissions are required:
- `contents: read` for reading repository contents.
- `contents: write` for pushing changes to the repository.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
